### PR TITLE
Remove extra padding when `event-display: "none"`

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -188,7 +188,8 @@
           // content descriptions for event
           
           content(
-            (event-pos.first(), line-pos1.last() + 0.7),
+            (event-pos.first(),
+            line-pos1.last() + if event-display == "none" { 0.15 } else { 0.7 }),
             angle: event-rotation,
             anchor: "mid-west",
             [ #x.title ]


### PR DESCRIPTION
This is much cleaner without random white-space.

Thank you for creating this awesome package.

Before
<img width="4660" height="694" alt="Screenshot_2025-12-16_14-28-52" src="https://github.com/user-attachments/assets/117ec99a-3fb2-4e78-b622-a06993731ed6" />
After
<img width="4574" height="570" alt="Screenshot_2025-12-16_14-27-30" src="https://github.com/user-attachments/assets/d349e0e2-5035-4900-9152-aef42af78330" />
